### PR TITLE
fixed #19 チーム分けを MatchingScore に反映する機能の追加

### DIFF
--- a/app/services/cancel_update_matching_scores_service.rb
+++ b/app/services/cancel_update_matching_scores_service.rb
@@ -1,0 +1,16 @@
+class CancelUpdateMatchingScoresService < BaseService
+  def initialize(group_set)
+    @group_set = group_set
+  end
+
+  def call
+    @group_set.groups.each do |group|
+      group.members.each do |member|
+        member.matching_score_set.cancel_update_scores_by_matching!(group.partners(member))
+        member.matching_score_set.cancel_update_scores_by_unmatching!(group.other_groups_users)
+      end
+    end
+    @group_set.applied = false
+    @group_set.save
+  end
+end

--- a/app/services/update_matching_scores_service.rb
+++ b/app/services/update_matching_scores_service.rb
@@ -1,0 +1,16 @@
+class UpdateMatchingScoresService < BaseService
+  def initialize(group_set)
+    @group_set = group_set
+  end
+
+  def call
+    @group_set.groups.each do |group|
+      group.members.each do |member|
+        member.matching_score_set.update_scores_by_matching!(group.partners(member))
+        member.matching_score_set.update_scores_by_unmatching!(group.other_groups_users)
+      end
+    end
+    @group_set.applied = true
+    @group_set.save
+  end
+end


### PR DESCRIPTION
https://github.com/tamago3keran/shuffle_lunch/issues/19

## やったこと
- [x] `UpdateMatchingScoresService` クラスの追加
- [x] `CancelUpdateMatchingScoresService` クラスの追加