### PR TITLE
fixed #33 お店編集画面・機能の作成

### DIFF
--- a/app/assets/stylesheets/restaurant.css
+++ b/app/assets/stylesheets/restaurant.css
@@ -126,3 +126,19 @@
   margin-top: 40px;
   margin-right: 30px;
 }
+
+/*お店編集ページのレイアウト*/
+.edit_restaurant_form {
+  width: 100%;
+}
+
+.btn_to_edit_restaurant {
+  width: 100px;
+  height: 30px;
+  position: absolute;
+  left: 70%;
+}
+
+.edit_restaurant {
+  position: relative;
+}

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -32,6 +32,7 @@ class RestaurantsController < ApplicationController
       flash[:notice] = "お店情報を更新しました"
       redirect_to @restaurant
     else
+      flash.now[:notice] = "お店の編集に失敗しました"
       render 'edit'
     end
   end

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -27,6 +27,16 @@ class RestaurantsController < ApplicationController
     @restaurant = Restaurant.find(params[:id])
   end
 
+  def update
+    @restaurant = Restaurant.find(params[:id])
+    if @restaurant.update_attributes(restaurant_params)
+      flash[:notice] = "お店情報を更新しました"
+      redirect_to @restaurant
+    else
+      render 'edit'
+    end
+  end
+
 
 
   private

--- a/app/views/restaurants/_form.html.haml
+++ b/app/views/restaurants/_form.html.haml
@@ -1,3 +1,3 @@
-= f.text_field :name, required: true, class: "name_of_restaurant"
-= f.text_field :url, required: true, class: "url_of_restaurant"
-= f.text_area :description, class: "description_of_restaurant"
+= f.text_field :name, placeholder: 'お店の名前', required: true, class: "name_of_restaurant"
+= f.text_field :url,  placeholder: 'お店のurl', required: true, class: "url_of_restaurant"
+= f.text_area :description, placeholder: 'お店詳細', class: "description_of_restaurant"

--- a/app/views/restaurants/_form.html.haml
+++ b/app/views/restaurants/_form.html.haml
@@ -1,0 +1,3 @@
+= f.text_field :name, required: true, class: "name_of_restaurant"
+= f.text_field :url, required: true, class: "url_of_restaurant"
+= f.text_area :description, class: "description_of_restaurant"

--- a/app/views/restaurants/edit.html.haml
+++ b/app/views/restaurants/edit.html.haml
@@ -1,0 +1,12 @@
+#js-user_index
+.main
+  %h1  お店情報を更新する
+  .edit_restaurant_form
+  = form_for @restaurant, url: restaurant_path, method: :patch do |f|
+    = f.text_field :name, value: @restaurant.name, required: true, class: "name_of_restaurant"
+    = f.text_field :url, value: @restaurant.url, required: true, class: "url_of_restaurant"
+    = f.text_area :description, value: @restaurant.description, class: "description_of_restaurant"
+    =submit_tag "更新する", class: "btn_to_edit_restaurant"
+  %br
+  =link_to "一覧に戻る", restaurants_path, class: "btn_back_to_index_page"
+= javascript_include_tag 'packs/user_index.bundle'

--- a/app/views/restaurants/edit.html.haml
+++ b/app/views/restaurants/edit.html.haml
@@ -3,9 +3,7 @@
   %h1  お店情報を更新する
   .edit_restaurant_form
   = form_for @restaurant, url: restaurant_path, method: :patch do |f|
-    = f.text_field :name, value: @restaurant.name, required: true, class: "name_of_restaurant"
-    = f.text_field :url, value: @restaurant.url, required: true, class: "url_of_restaurant"
-    = f.text_area :description, value: @restaurant.description, class: "description_of_restaurant"
+    = render partial: 'form', locals: {f: f}
     =submit_tag "更新する", class: "btn_to_edit_restaurant"
   %br
   =link_to "一覧に戻る", restaurants_path, class: "btn_back_to_index_page"

--- a/app/views/restaurants/new.html.haml
+++ b/app/views/restaurants/new.html.haml
@@ -3,9 +3,7 @@
   %h1  お店を追加する
   .add_restaurant_form
   = form_for @restaurant, url: restaurants_path do |f|
-    = f.text_field :name, placeholder: 'お店の名前', value: nil, required: true, class: "name_of_restaurant"
-    = f.text_field :url, placeholder: 'お店のurl', value: nil, required: true, class: "url_of_restaurant"
-    = f.text_area :description, placeholder: 'お店詳細', value: nil, class: "description_of_restaurant"
+    = render partial: 'form', locals: {f: f}
     =submit_tag "追加する", class: "btn_to_add_restaurant"
   %br
   =link_to "一覧に戻る", restaurants_path, class: "btn_back_to_index_page"


### PR DESCRIPTION
⚠️差分をわかりやすくするため・お店詳細画面で設定した編集ボタンを使用するため、詳細画面で使用したブランチからブランチを切っています。slsup/making_show_detail_pageがマージされ次第、PR先を変更いたします！
## 目的
登録されているお店の名前・URL・詳細を変更できるようにする。
## やったこと
・viewファイルでedit.html.hamlで画面作成
・コントローラファイルでupdateアクションを作成
・レイアウトを簡単に整えた。
![スクリーンショット 2020-01-09 15 39 31](https://user-images.githubusercontent.com/52365982/72053697-de456200-330a-11ea-86f7-bd1455e7a107.png)

## 動作確認
編集が反映されることは確認済みです。
## 備考
・flashメッセージをupdateアクション内で書いているが、#37と同様表示はしていない。
・#48で余力があれば実装する予定。