### PR TITLE
fixed #63 お店一覧ページに登録日を表示

### DIFF
--- a/app/assets/stylesheets/restaurant.css
+++ b/app/assets/stylesheets/restaurant.css
@@ -16,14 +16,13 @@
 
 .restaurant_index {
   width: 100%;
-  height: 7%;
+  height: 5%;
   padding: 5px 30px;
   border: 1px solid #c0bdbd;
 }
 
 .restaurant_index > a {
-  display: flex;
-  margin-left: 70%;
+  float: right;
 }
 
 .pagination {

--- a/app/assets/stylesheets/restaurant.css
+++ b/app/assets/stylesheets/restaurant.css
@@ -16,6 +16,7 @@
 
 .restaurant_index {
   width: 100%;
+  height: 7%;
   padding: 5px 30px;
   border: 1px solid #c0bdbd;
 }
@@ -77,6 +78,10 @@
 
 .new_restaurant {
   position: relative;
+}
+
+.restaurant_registered_time {
+  font-size: 12px;
 }
 
 /*お店詳細ページのスタイリング*/

--- a/app/views/restaurants/index.html.haml
+++ b/app/views/restaurants/index.html.haml
@@ -8,7 +8,7 @@
       = restaurant.name 
       = link_to "お店の詳細", restaurant_path(restaurant)
       .restaurant_registered_time
-        = "登録時間：#{restaurant.created_at.strftime('%Y年%m月%d日')}"
+        = "登録日：#{restaurant.created_at.strftime('%Y年%m月%d日')}"
   = paginate(@restaurants)
   = javascript_include_tag 'packs/user_index.bundle'
   

--- a/app/views/restaurants/index.html.haml
+++ b/app/views/restaurants/index.html.haml
@@ -7,6 +7,8 @@
     .restaurant_index
       = restaurant.name 
       = link_to "お店の詳細", restaurant_path(restaurant)
+      .restaurant_registered_time
+        = "登録時間：#{restaurant.created_at.strftime('%Y年%m月%d日')}"
   = paginate(@restaurants)
   = javascript_include_tag 'packs/user_index.bundle'
   


### PR DESCRIPTION
### 目的
レストランが登録された日時を表示する。

### やったこと
- ```restaurants/index.html.haml```ファイルを編集し、登録された時間を表示
- それに伴い```restaurant.css```でレイアウトを編集

### 画面
<img width="936" alt="スクリーンショット 2020-01-16 19 35 53" src="https://user-images.githubusercontent.com/52365982/72517845-6f7e8080-3897-11ea-85b9-c86b027b08ec.png">

### 備考
イシューで作成した段階では右側に表示する予定だったが、cssでスタイリングする際に```aplication.css```を編集する必要があり、他の画面へ影響が出そうだったので一旦左寄せでスタイリングした。#64で余力があればスタイリングをさらに整えてもらう予定。