### PR TITLE
fixed #67 モーダルの文言修正

### DIFF
--- a/app/views/restaurants/show.html.haml
+++ b/app/views/restaurants/show.html.haml
@@ -26,9 +26,9 @@
     = form_for @restaurant.restaurant_notes.build, url: restaurant_restaurant_notes_path(params[:id]) do |f|
       = f.text_field :writer_name, placeholder: '名前', value: nil, required: true, class: "form_of_writer_name"
       = f.text_area :comment, placeholder: '口コミ', value: nil, required: true, class: "form_of_comment"
-      =submit_tag "投稿する", class: "btn_to_add_comment", data: {confirm: "この口コミを登録しますか？"}
+      =submit_tag "投稿する", class: "btn_to_add_comment", data: {confirm: "口コミは一度登録されると編集・削除ができません！本当にこの口コミを登録しますか？"}
   %br
   = link_to "一覧に戻る", restaurants_path, class: "btn_back_to_index_page"
   = link_to "編集する", edit_restaurant_path, class: "btn_to_edit_page"
-  = link_to "削除する", restaurant_path, method: :delete, data: {confirm: "本当に削除しますか？"}, class: "btn_to_delete_restaurant"
+  = link_to "削除する", restaurant_path, method: :delete, data: {confirm: "お店を削除すると今まで投稿された口コミも削除されます！本当に削除しますか？"}, class: "btn_to_delete_restaurant"
   = javascript_include_tag 'packs/restaurant_show.bundle'


### PR DESCRIPTION
### 目的
お店の削除時・口コミ投稿時に表示するモーダルの修正

### やったこと
views/restaurants/editファイルで以下の変更を加えた。
- 「削除する」リンクに対して、confirm: "お店を削除すると今まで投稿された口コミも削除されます！本当に削除しますか？"を設定。
- 「投稿する」リンクに対して、confirm: "口コミは一度登録されると編集・削除ができません！本当にこの口コミを登録しますか？"を設定。
### 画面
口コミ投稿時のモーダル
<img width="458" alt="スクリーンショット 2020-01-20 15 04 44" src="https://user-images.githubusercontent.com/52365982/72702529-5ecf5280-3b96-11ea-8bae-e029cb248687.png">

お店削除時のモーダル
<img width="456" alt="スクリーンショット 2020-01-20 15 04 15" src="https://user-images.githubusercontent.com/52365982/72702531-6131ac80-3b96-11ea-8609-b9d888e71311.png">

