### PR TITLE
fixed #85 お店新規登録後のリダイレクト動作不具合

### DIFF
--- a/app/controllers/group_sets/groups_controller.rb
+++ b/app/controllers/group_sets/groups_controller.rb
@@ -3,9 +3,7 @@ class GroupSets::GroupsController < ApplicationController
 
   def show; end
 
-  def edit
-    session[:forward_url] = request.url
-  end
+  def edit; end
 
   def update
     if @group.update_attributes(restaurant: params[:group][:restaurant])

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -28,7 +28,11 @@ class RestaurantsController < ApplicationController
     @restaurant = Restaurant.new(restaurant_params)
     if @restaurant.save
       flash[:notice] = "お店登録に成功しました！"
-      redirect_to session[:forward_url]
+      if session[:forward_url].include?("/restaurants")
+        redirect_to restaurant_path(@restaurant)
+      else
+        redirect_to session[:forward_url]
+      end
     else
       flash.now[:error] = "お店登録に失敗しました！"
       render :new

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -10,8 +10,7 @@ class RestaurantsController < ApplicationController
 
   def new
     @restaurant = Restaurant.new
-    @forward_url = session[:forward_url]
-    session[:forward_url] = nil
+    session[:forward_url] = request.referrer
   end
 
   def destroy
@@ -27,14 +26,9 @@ class RestaurantsController < ApplicationController
 
   def create
     @restaurant = Restaurant.new(restaurant_params)
-    @forward_url = params[:forward_url]
     if @restaurant.save
       flash[:notice] = "お店登録に成功しました！"
-      if @forward_url
-        redirect_to @forward_url
-      else
-        redirect_to restaurants_path
-      end
+      redirect_to session[:forward_url]
     else
       flash.now[:error] = "お店登録に失敗しました！"
       render :new

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -33,6 +33,7 @@ class RestaurantsController < ApplicationController
       else
         redirect_to session[:forward_url]
       end
+      session[:forward_url] = nil
     else
       flash.now[:error] = "お店登録に失敗しました！"
       render :new

--- a/app/views/restaurants/new.html.haml
+++ b/app/views/restaurants/new.html.haml
@@ -4,7 +4,6 @@
     %h1 お店を追加する
   .form_item
     = form_for @restaurant, url: restaurants_path do |f|
-      = hidden_field_tag :forward_url, @forward_url
       = render partial: 'form', locals: {f: f}
       .input
         %p= f.submit "追加する", class: "submit"


### PR DESCRIPTION
#85 
## 目的
- お店を新たに登録した際(`restaurants#create`)に、最後に閲覧したグループ編集ページに遷移されてしまっていた不具合を修正する。

## 対応内容
- 直前のアクションもしくはURLで判別する必要があるため、グループ編集ページでsessionに代入するのではなく`restaurants#new`で`session[:forward_url]=request.referrer`を代入し、`restaurants#create`後のリダイレクト先を`session[:forward_url]`にすることで、正常なリダイレクトになりました。
- さらなる動作改善として、通常通りお店一覧ページからお店作成ページに遷移して作成した場合には、その作成したお店の詳細ページにリダイレクトするよう改善しました。今後ソート機能などを追加した場合に、登録したお店がどこか分からないというようなケースにも対応できるかと思います。