### PR TITLE
fixed #81 groupモデルのテスト実装

### DIFF
--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -38,4 +38,27 @@ describe Group do
       expect(best_partner).to eq partner1
     end
   end
+
+  describe "association with restaurant" do
+    let(:association) do
+      described_class.reflect_on_association(:restaurant)
+    end
+    let(:restaurant) { Restaurant.create(name: "restaurant", url: "http://example.com", description: "delicious") }
+    let(:group_set) { GroupSet.create }
+    let(:group) { Group.new(group_set_id: group_set.id, member_ids: [user.id, partner1.id, partner2.id]) }
+
+    it "returns associated class name" do
+      expect(association.class_name).to eq "Restaurant"
+    end
+
+    it "belongs to restaurant" do
+      group.restaurant = restaurant
+      expect(group).to be_valid
+    end
+
+    it "belongs to restaurant optionally" do
+      group.restaurant = nil
+      expect(group).to be_valid
+    end
+  end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -40,16 +40,9 @@ describe Group do
   end
 
   describe "association with restaurant" do
-    let(:association) do
-      described_class.reflect_on_association(:restaurant)
-    end
     let(:restaurant) { Restaurant.create(name: "restaurant", url: "http://example.com", description: "delicious") }
     let(:group_set) { GroupSet.create }
     let(:group) { Group.new(group_set_id: group_set.id, member_ids: [user.id, partner1.id, partner2.id]) }
-
-    it "returns associated class name" do
-      expect(association.class_name).to eq "Restaurant"
-    end
 
     it "belongs to restaurant" do
       group.restaurant = restaurant


### PR DESCRIPTION
#81  

## 目的
- 新たに追加した`restaurant`モデルと正常に関連づけられているかをテストする。
- 関連付けには`optional: true`を指定しているので、関連がなくても有効であるかをテストする。

## 対応内容
- 関連付けられたクラス名が`restaurant`であるかのテスト
- レストランモデルとの関連付けが有効であるかのテスト
- レストランモデルとの関連付けが無くとも有効であるかのテスト
![groupmodelspec](https://user-images.githubusercontent.com/50792855/73034562-9edd5080-3e88-11ea-9c66-6b66009d813a.png)
