### PR TITLE
fixed #93 最新のグループ分けの詳細ページをHOME画面表示

### DIFF
--- a/app/controllers/group_sets_controller.rb
+++ b/app/controllers/group_sets_controller.rb
@@ -11,8 +11,8 @@ class GroupSetsController < ApplicationController
       when :index
         @group_sets = GroupSet.all.desc(:created_at).page(params[:page]).per(10)
       when :show
-        if request.fullpath == "/"
-          @group_set = GroupSet.last
+        if request.fullpath == root_path
+          @group_set = GroupSet.all.desc(:created_at).first
         else
           @group_set = GroupSet.find(params[:id])
         end

--- a/app/controllers/group_sets_controller.rb
+++ b/app/controllers/group_sets_controller.rb
@@ -11,7 +11,11 @@ class GroupSetsController < ApplicationController
       when :index
         @group_sets = GroupSet.all.desc(:created_at).page(params[:page]).per(10)
       when :show
-        @group_set = GroupSet.find(params[:id])
+        if request.fullpath == "/"
+          @group_set = GroupSet.last
+        else
+          @group_set = GroupSet.find(params[:id])
+        end
         @groups = @group_set.groups
       end
     end

--- a/app/views/group_sets/show.html.haml
+++ b/app/views/group_sets/show.html.haml
@@ -1,7 +1,10 @@
 #js-group_set_show
 .main
   .item
-    %h1 #{@group_set.created_at.strftime('%Y年%m月%d日')}のグループ
+    - if current_page?(root_path)
+      %h1 今日のグループ
+    - else
+      %h1 #{@group_set.created_at.strftime('%Y年%m月%d日')}のグループ
   .index_item
     - @groups.each_with_index do |group, i|
       = link_to group_set_group_path(@group_set, group, group_number: i+1), class: "groups" do

--- a/app/views/group_sets/show.html.haml
+++ b/app/views/group_sets/show.html.haml
@@ -1,7 +1,7 @@
 #js-group_set_show
 .main
   .item
-    - if current_page?(root_path)
+    - if @group_set.created_at.today?
       %h1 今日のグループ
     - else
       %h1 #{@group_set.created_at.strftime('%Y年%m月%d日')}のグループ

--- a/app/views/group_sets/show.html.haml
+++ b/app/views/group_sets/show.html.haml
@@ -1,10 +1,9 @@
 #js-group_set_show
 .main
   .item
-    - if @group_set.created_at.today?
-      %h1 今日のグループ
-    - else
-      %h1 #{@group_set.created_at.strftime('%Y年%m月%d日')}のグループ
+    %h1 シャッフルランチ
+  .item
+    %h2 #{@group_set.created_at.strftime('%Y年%m月%d日')}のグループ
   .index_item
     - @groups.each_with_index do |group, i|
       = link_to group_set_group_path(@group_set, group, group_number: i+1), class: "groups" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root to: "group_sets#index"
+  root to: "group_sets#show"
   resources :restaurants do
     resources :restaurant_notes, only: [:create]
   end


### PR DESCRIPTION
#93 
## 目的
- ユースケースを想定してグループがすぐ確認できるよう、最新のグループ分け詳細ページにする改善を行う。
## 対応内容
- HOME画面を過去のグループ分け一覧ページではなく、最新のグループ分け詳細ページに設定しました。
- `created_at`が当日であれば、「今日のグループ」と表示されるようにしました。
- 当日でない場合も直近のグループ分けを編集することが実利用では多いだろうという意図で、GroupSetのデータ抽出は`GroupSet.last`で取得しています。
![todaysgroupshow](https://user-images.githubusercontent.com/50792855/73040236-2bddd500-3e9c-11ea-9f73-c20c2f82053e.png)

## 備考
- 「今日のグループ」の文言表示の判定は、日本時間で対応していることを確認済みです。