### PR TITLE
fixed #110 お店のリンク改善

### DIFF
--- a/app/assets/stylesheets/group_sets.css
+++ b/app/assets/stylesheets/group_sets.css
@@ -108,6 +108,20 @@ a.groups {
   width: 50%;
 }
 
+.group_restaurant_link {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  color: #000;
+  padding: 0 5px;
+  margin-bottom: 10px;
+}
+
+.group_restaurant_link:hover {
+  border-radius: 5px;
+  background-color: #cce4ff;
+}
+
 .groups_restaurant_description_blank {
   color: #666;
   text-align: center;

--- a/app/views/group_sets/groups/show.html.haml
+++ b/app/views/group_sets/groups/show.html.haml
@@ -9,14 +9,15 @@
         %p= "#{member.full_name}"
     - if @group.restaurant.present?
       .group_show_restaurant
-        .group_restaurant_name
-          %h2= @group.restaurant.name
-        - if @group.restaurant.description.present?
-          .groups_restaurant_description
-            %p= @group.restaurant.description
-        - else
-          .groups_restaurant_description_blank
-            %p お店詳細ページから詳しい説明を入力しよう！
+        = link_to restaurant_path(@group.restaurant), class: "group_restaurant_link" do
+          .group_restaurant_name
+            %h2= @group.restaurant.name
+          - if @group.restaurant.description.present?
+            .groups_restaurant_description
+              %p= @group.restaurant.description
+          - else
+            .groups_restaurant_description_blank
+              %p お店詳細ページから詳しい説明を入力しよう！
         .group_restaurant_url
           お店URL :
           = link_to @group.restaurant.url, @group.restaurant.url, target: "_blank"

--- a/app/views/restaurants/show.html.haml
+++ b/app/views/restaurants/show.html.haml
@@ -3,7 +3,7 @@
   .restaurant_name
     %h1= @restaurant.name
   .restaurant_url
-    =link_to @restaurant.url, target: "_blank"
+    =link_to @restaurant.url, @restaurant.url, target: "_blank"
   - if @restaurant.description.present?
     .show_description
       = @restaurant.description


### PR DESCRIPTION
## 目的
- グループ詳細ページのお店情報からお店詳細ページに遷移できるようにリンクにする。
- お店詳細ページのお店URLがリンク遷移しない不具合を修正する。
## 対応内容
- グループ詳細ページで表示されているお店の名前および詳細を、お店詳細ページへのリンクに変更した。
- お店詳細ページのお店URLがリンクとして正常に動作しない不具合を改善した。
![Jan-29-2020 17-33-37](https://user-images.githubusercontent.com/50792855/73340174-98ead380-42bd-11ea-9ec4-98941e2f1c53.gif)
